### PR TITLE
fix: scope rescuer fetch to forwarded session

### DIFF
--- a/blobstore.py
+++ b/blobstore.py
@@ -304,6 +304,17 @@ class BlobStore:
 
         cap = self.cfg.get("fetch_max_chars", 4000)
         bpath = self.blob_dir / blob_id
+
+        # Session scoping: when the host forwards session_id, the fetch tool
+        # should not become a cross-session oracle for guessed capability ids.
+        # Keep the empty-session fallback for older/single-session Hermes
+        # dispatchers that do not pass session_id yet.
+        if session_id and not self.session_references(blob_id, session_id):
+            tomb = self._tombstone_msg(blob_id, session_id)
+            if tomb:
+                return tomb
+            return f"Error: blob {blob_id} not available in this session"
+
         if not bpath.exists():
             tomb = self._tombstone_msg(blob_id, session_id)
             if tomb:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,0 +1,11 @@
+name: toolaria
+version: "0.1.0"
+description: "Rescue oversized tool results before they flood context with a SHA256-addressed blob store and rescuer_fetch."
+author: "Sahil-SS9"
+kind: standalone
+provides_tools:
+  - rescuer_fetch
+provides_hooks:
+  - transform_tool_result
+  - on_session_start
+  - on_session_end

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -197,10 +197,30 @@ def test_stat_with_forwarded_session_id(plugin, toolaria):
 
 
 def test_stat_without_session_searches_indexes(plugin, toolaria):
-    """stat finds the tool name even when no session id is forwarded."""
+    """stat finds the tool name when legacy dispatchers forward no session id."""
     bid = toolaria._store.put("s" * 2500, "mcp_tool", session_id="some-s")
     r = toolaria._fetch(args={"id": bid, "mode": "stat"})
     assert "mcp_tool" in r
+
+
+def test_fetch_with_forwarded_session_denies_cross_session_read(plugin, toolaria):
+    """A forwarded session_id turns rescuer_fetch into a session-scoped read.
+
+    Blob ids are short capabilities. When the host knows the calling session,
+    a guessed id from another session must not reveal bytes or metadata.
+    """
+    bid = toolaria._store.put("SECRET DATA", "web_search", session_id="owner-s")
+    r = toolaria._fetch(args={"id": bid, "mode": "range", "start": 0, "count": 1},
+                        session_id="other-s")
+    assert "not available in this session" in r
+    assert "SECRET" not in r
+
+
+def test_fetch_without_session_keeps_legacy_global_read(plugin, toolaria):
+    """Back-compat: older Hermes dispatchers may not pass session_id yet."""
+    bid = toolaria._store.put("LEGACY READ", "web_search", session_id="owner-s")
+    r = toolaria._fetch(args={"id": bid, "mode": "range", "start": 0, "count": 1})
+    assert "LEGACY READ" in r
 
 
 def test_dedup(plugin, toolaria):
@@ -419,10 +439,11 @@ def test_tombstone_not_served_cross_session(plugin, toolaria):
     idx["blobs"][bid]["t"] = time.time() - 7200
     toolaria._store._save_idx(idx, "owner")
     toolaria._store.lazy_sweep()
-    # Another session fetching the same id gets the bare not-found, no tool name
+    # Another session gets a generic session-scoped denial, with no tool name
+    # or size from the owner session's tombstone.
     r = toolaria._fetch(args={"id": bid, "mode": "stat"}, session_id="intruder")
     assert "web_extract" not in r
-    assert "not found" in r
+    assert "not available in this session" in r
 
 
 def test_size_sweep_also_tombstones(plugin, toolaria):


### PR DESCRIPTION
## Summary

Adds Hermes plugin metadata and tightens `rescuer_fetch` session scoping when the host forwards a `session_id`.

Changes:
- Add `plugin.yaml` so Hermes' plugin loader can discover and register Toolaria as a directory plugin.
- Make `BlobStore.fetch(...)` deny cross-session reads when `session_id` is supplied.
- Preserve legacy behavior when no `session_id` is forwarded, so older/single-session dispatchers still work.
- Add regression tests for session-scoped fetch, legacy fetch compatibility, and tombstone non-disclosure wording.

## Why

Toolaria blob ids are short capabilities. If the host knows the caller session, `rescuer_fetch` should not reveal bytes or metadata for a blob that the caller session does not reference. This matches the stricter behavior already used by pass-by-reference token expansion.

## Test plan

Run in an isolated lab checkout:

```bash
uv venv .venv
. .venv/bin/activate
uv pip install -r requirements.txt pytest
pytest -q
```

Observed:

```text
94 passed in 0.23s
```

Additional isolated Hermes PluginManager smoke:

```text
loaded_enabled True
loaded_error None
registered toolaria with rescuer_fetch/hooks/middleware
same-session fetch: returns expected grep result
cross-session fetch: Error: blob ... not available in this session
passref disabled: no expansion
```

Post-patch benchmark highlights:

- 263k JSON: rescue 9.1 ms, 91.9x reduction.
- 1.61MB logs / 30k lines: rescue 83.3 ms, 417.8x reduction.
- 233k markdown: rescue 12.2 ms, 79.5x reduction.
- Regex installed: email grep works; catastrophic-style negative grep returns in 0.296 ms.
- TTL sweep deletes blob and leaves same-session tombstone guidance.

## Compatibility notes

- If `session_id` is omitted, fetch keeps the previous global lookup behavior for backward compatibility.
- When `session_id` is present but the session does not own/reference the blob, the error is intentionally generic and does not reveal owner-session tool names or sizes.
